### PR TITLE
[#38] Swagger 설정(springdocs + Swagger UI)

### DIFF
--- a/hotelking-admin/build.gradle
+++ b/hotelking-admin/build.gradle
@@ -6,6 +6,9 @@ repositories {
 }
 
 dependencies {
+    // openapi & swagger ui
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/hotelking-admin/src/main/java/com/hotelking/config/OpenApiConfig.java
+++ b/hotelking-admin/src/main/java/com/hotelking/config/OpenApiConfig.java
@@ -7,6 +7,13 @@ import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
     info = @Info(
@@ -31,6 +38,64 @@ import io.swagger.v3.oas.annotations.servers.Server;
     bearerFormat = "JWT",
     in = SecuritySchemeIn.HEADER
 )
+@Configuration
 public class OpenApiConfig {
+
+
+  @Bean
+  public OpenApiCustomizer customerGlobalHeaderOpenApiCustomizer() {
+    return openApi -> openApi.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation -> {
+      ApiResponses apiResponses = operation.getResponses();
+      apiResponses.forEach((statusCode, apiResponse) -> {
+        if ("200".equals(statusCode)) {
+          Content content = apiResponse.getContent();
+          if (content != null) {
+            content.forEach((mediaTypeKey, mediaType) -> {
+              Schema<?> originalSchema = mediaType.getSchema();
+              if (isApiResponseVoidSchema(originalSchema)) {
+                mediaType.setSchema(createSuccessSchema());
+              } else {
+                // 기존 schema 에서 data 필드만 가져옵니다.
+                Schema<?> refSchema = getSchemaByRef(openApi, originalSchema.get$ref());
+                Schema<?> dataSchema = extractDataSchema(refSchema);
+                mediaType.setSchema(createSuccessSchemaWithData(dataSchema));
+              }
+            });
+          }
+        }
+      });
+    }));
+  }
+
+  private Schema<?> getSchemaByRef(OpenAPI api, String ref) {
+    if (ref.startsWith("#/components/schemas/")) {
+      String schemaName = ref.substring("#/components/schemas/".length());
+      return api.getComponents().getSchemas().get(schemaName);
+    }
+    throw new IllegalArgumentException("Invalid reference format: " + ref);
+  }
+
+  private Schema<?> extractDataSchema(Schema<?> originalSchema) {
+    if (originalSchema.getProperties() != null && originalSchema.getProperties().containsKey("data")) {
+      return (Schema<?>) originalSchema.getProperties().get("data");
+    }
+    return originalSchema;
+  }
+
+  private boolean isApiResponseVoidSchema(Schema<?> schema) {
+    return schema.get$ref().equals("#/components/schemas/ApiResponseVoid");
+  }
+
+  private Schema<?> createSuccessSchema() {
+    Schema<?> successSchema = new Schema<>();
+    successSchema.addProperty("result", new Schema<>().type("string").example("success"));
+    return successSchema;
+  }
+
+  private Schema<?> createSuccessSchemaWithData(Schema<?> dataSchema) {
+    Schema<?> successSchema = createSuccessSchema();
+    successSchema.addProperty("data", dataSchema);
+    return successSchema;
+  }
 
 }

--- a/hotelking-admin/src/main/java/com/hotelking/config/OpenApiConfig.java
+++ b/hotelking-admin/src/main/java/com/hotelking/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.hotelking.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@OpenAPIDefinition(
+    info = @Info(
+        contact = @Contact(
+            name = "minshik kim"
+        ),
+        description = "호텔킹 프로젝트 OpenApi 문서",
+        title = "호텔킹 API 문서"
+    ),
+    servers = {
+        @Server(
+            description = "Local ENV",
+            url = "https://localhost:8080"
+        )
+    }
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    description = "JWT auth description",
+    scheme = "bearer",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    in = SecuritySchemeIn.HEADER
+)
+public class OpenApiConfig {
+
+}

--- a/hotelking-admin/src/main/java/com/hotelking/config/WebConfig.java
+++ b/hotelking-admin/src/main/java/com/hotelking/config/WebConfig.java
@@ -18,6 +18,12 @@ public class WebConfig implements WebMvcConfigurer {
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loginInterceptor)
         .addPathPatterns("/**")
-        .excludePathPatterns("/admin/**");
+        .excludePathPatterns(
+            // swagger
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/swagger-ui/**",
+            "/webjars/**"
+        );
   }
 }

--- a/hotelking-admin/src/main/java/com/hotelking/controller/HotelManagementController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/HotelManagementController.java
@@ -3,6 +3,7 @@ package com.hotelking.controller;
 import com.hotelking.application.AddHotelService;
 import com.hotelking.dto.request.AddHotelRequest;
 import com.hotelking.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +20,8 @@ public class HotelManagementController {
   }
 
   @PostMapping("/admin/hotels")
-  public ApiResponse<?> registerHotel(@RequestBody AddHotelRequest addHotelRequest) {
+  @Operation(summary = "새로운 호텔 등록", description = "새로운 호텔을 등록합니다.")
+  public ApiResponse<Void> registerHotel(@RequestBody AddHotelRequest addHotelRequest) {
     addHotelRequest.validationCheck();
     addHotelService.registerHotel(addHotelRequest.toAddHotel());
     return ApiResponse.success();

--- a/hotelking-admin/src/main/java/com/hotelking/controller/HotelManagementController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/HotelManagementController.java
@@ -3,11 +3,13 @@ package com.hotelking.controller;
 import com.hotelking.application.AddHotelService;
 import com.hotelking.dto.request.AddHotelRequest;
 import com.hotelking.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Hotel", description = "Manage hotel")
 public class HotelManagementController {
 
   private final AddHotelService addHotelService;

--- a/hotelking-admin/src/main/java/com/hotelking/controller/ReservationManagementController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/ReservationManagementController.java
@@ -2,8 +2,9 @@ package com.hotelking.controller;
 
 import com.hotelking.application.ReservationScheduleService;
 import com.hotelking.dto.request.AddReservationScheduleRequest;
+import com.hotelking.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +20,11 @@ public class ReservationManagementController {
   }
 
   @PostMapping("/admin/reservation/register-schedule")
-  public ResponseEntity<Void> addReservationSchedule(@RequestBody AddReservationScheduleRequest addReservationScheduleRequest) {
+  @Operation(summary = "예약 - 룸 스케줄 매칭", description = "사용자가 예약한 건과 방 스케줄을 매칭합니다.")
+  public ApiResponse<Void> addReservationSchedule(
+      @RequestBody AddReservationScheduleRequest addReservationScheduleRequest
+  ) {
     reservationService.registerReservationSchedule(addReservationScheduleRequest.toDto());
-    return ResponseEntity.ok().build();
+    return ApiResponse.success();
   }
 }

--- a/hotelking-admin/src/main/java/com/hotelking/controller/ReservationManagementController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/ReservationManagementController.java
@@ -2,12 +2,14 @@ package com.hotelking.controller;
 
 import com.hotelking.application.ReservationScheduleService;
 import com.hotelking.dto.request.AddReservationScheduleRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Reservation", description = "Manage Client Reservation")
 public class ReservationManagementController {
 
   private final ReservationScheduleService reservationService;
@@ -17,9 +19,7 @@ public class ReservationManagementController {
   }
 
   @PostMapping("/admin/reservation/register-schedule")
-  public ResponseEntity<Void> addReservationSchedule(
-      @RequestBody AddReservationScheduleRequest addReservationScheduleRequest
-  ) {
+  public ResponseEntity<Void> addReservationSchedule(@RequestBody AddReservationScheduleRequest addReservationScheduleRequest) {
     reservationService.registerReservationSchedule(addReservationScheduleRequest.toDto());
     return ResponseEntity.ok().build();
   }

--- a/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchController.java
@@ -4,8 +4,10 @@ import com.hotelking.application.Paging;
 import com.hotelking.application.RoomSearchService;
 import com.hotelking.dto.response.ApiResponse;
 import com.hotelking.dto.response.RoomResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,9 +24,10 @@ public class RoomSearchController {
   }
 
   @GetMapping("/admin/search/rooms")
+  @Operation(summary = "이용가능한 룸을 조회", description = "검색 날짜에 비어있는 룸을 조회한다.")
   public ApiResponse<Paging<List<RoomResponse>>> searchAvailableRooms(
-      RoomSearchCriteria searchCriteria,
-      @PageableDefault(size = 100) Pageable pageable
+      @ParameterObject RoomSearchCriteria searchCriteria,
+      @ParameterObject @PageableDefault(size = 100) Pageable pageable
   ) {
     searchCriteria.validationCheck();
     Paging<List<RoomResponse>> listPaging = roomSearchService.searchRooms(searchCriteria.toParam(), pageable);

--- a/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchController.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchController.java
@@ -2,8 +2,9 @@ package com.hotelking.controller;
 
 import com.hotelking.application.Paging;
 import com.hotelking.application.RoomSearchService;
-import com.hotelking.dto.response.RoomResponse;
 import com.hotelking.dto.response.ApiResponse;
+import com.hotelking.dto.response.RoomResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Search", description = "Search Room or Schedule")
 public class RoomSearchController {
 
   private final RoomSearchService roomSearchService;

--- a/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchCriteria.java
+++ b/hotelking-admin/src/main/java/com/hotelking/controller/RoomSearchCriteria.java
@@ -5,21 +5,21 @@ import com.hotelking.dto.RequestDtoCheckable;
 import com.hotelking.dto.query.RoomAllocationType;
 import com.hotelking.exception.ErrorCode;
 import com.hotelking.exception.HotelkingException;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
-// swagger 표시 잘 되는 지 확인하기, 파라미터 표시될까? 객체로 ? 어떻게 되는 지 보자
-// 살펴보자
-// 객체로 받을 때 요청값 validation 잘하기
+
 @Builder
 public record RoomSearchCriteria(
-    RoomAllocationType allocationType,
-    List<Long> types,
-    LocalDate checkInDate,
-    LocalDate checkOutDate,
-    ReservationType reservationType,
-    boolean reserved
+    @Schema(description = "룸 할당 종류(하나 또는 복수)", implementation = RoomAllocationType.class, requiredMode = RequiredMode.REQUIRED) RoomAllocationType allocationType,
+    @Schema(description = "룸 타입 리스트", type = "list<number>", example = "1, 2, 3", requiredMode = RequiredMode.REQUIRED) List<Long> types,
+    @Schema(description = "체크인 날짜", format = "yyyy-MM-dd", example = "2024-06-05", requiredMode = RequiredMode.REQUIRED) LocalDate checkInDate,
+    @Schema(description = "체크아웃 날짜", format = "yyyy-MM-dd", example = "2024-06-07", requiredMode = RequiredMode.REQUIRED) LocalDate checkOutDate,
+    @Schema(description = "예약 타입(숙박, 대실, 전부)", implementation = ReservationType.class, requiredMode = RequiredMode.REQUIRED) ReservationType reservationType,
+    @Schema(description = "예약유무", type = "boolean", defaultValue = "false", requiredMode = RequiredMode.NOT_REQUIRED) boolean reserved
 ) implements RequestDtoCheckable {
 
   @Override

--- a/hotelking-admin/src/main/java/com/hotelking/dto/request/AddHotelRequest.java
+++ b/hotelking-admin/src/main/java/com/hotelking/dto/request/AddHotelRequest.java
@@ -4,6 +4,8 @@ import com.hotelking.dto.AddHotelDto;
 import com.hotelking.dto.RequestDtoCheckable;
 import com.hotelking.exception.ErrorCode;
 import com.hotelking.exception.HotelkingException;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,9 +13,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AddHotelRequest implements RequestDtoCheckable {
 
+  @Schema(description = "호텔 이름", requiredMode = RequiredMode.REQUIRED)
   private String hotelName;
+
+  @Schema(description = "호텔 주소", requiredMode = RequiredMode.REQUIRED)
   private String hotelAddress;
+
+  @Schema(description = "호텔 위도", type = "double", requiredMode = RequiredMode.NOT_REQUIRED)
   private double hotelLat;
+
+  @Schema(description = "호텔 경도", type = "double", requiredMode = RequiredMode.NOT_REQUIRED)
   private double hotelLng;
 
   public AddHotelDto toAddHotel() {

--- a/hotelking-admin/src/main/java/com/hotelking/dto/request/AddReservationScheduleRequest.java
+++ b/hotelking-admin/src/main/java/com/hotelking/dto/request/AddReservationScheduleRequest.java
@@ -1,8 +1,14 @@
 package com.hotelking.dto.request;
 
 import com.hotelking.dto.AddReservationScheduleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
 
-public record AddReservationScheduleRequest(long reservationId, long roomId) {
+@ParameterObject
+public record AddReservationScheduleRequest(
+    @Schema(description = "예약 번호", type = "number", minimum = "1") long reservationId,
+    @Schema(description = "룸 번호", type = "number", minimum = "1") long roomId
+) {
 
   public AddReservationScheduleDto toDto() {
     return new AddReservationScheduleDto(reservationId, roomId);

--- a/hotelking-admin/src/main/resources/application-local.yml
+++ b/hotelking-admin/src/main/resources/application-local.yml
@@ -25,3 +25,6 @@ jwt:
   secret-key: aG90ZWxraW5naGVsbG8K
   access-life-time-sec: 86400      # 1일
   refresh-life-time-sec: 15552000  # 6개월 (86400 * 30 * 6(개월))
+
+springdoc:
+  default-produces-media-type: application/json

--- a/hotelking-admin/src/main/resources/application-local.yml
+++ b/hotelking-admin/src/main/resources/application-local.yml
@@ -20,3 +20,8 @@ spring:
 
     defer-datasource-initialization: true
     generate-ddl: true
+
+jwt:
+  secret-key: aG90ZWxraW5naGVsbG8K
+  access-life-time-sec: 86400      # 1일
+  refresh-life-time-sec: 15552000  # 6개월 (86400 * 30 * 6(개월))


### PR DESCRIPTION
### 🎋 연관된 이슈 번호(선택)
#38 

### 💡 작업동기
- 작업 배경을 알려주세요.

### 🔑 주요 변경사항 및 작업목록
- API 문서로 Swagger UI + Springdocs 사용
- 공통 응답 만들기

### 관련 이슈(특히 에러)
- 공통 응답 만드는 부분
```java

@Bean
  public OpenApiCustomizer customerGlobalHeaderOpenApiCustomizer() {
    return openApi -> openApi.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation -> {
      ApiResponses apiResponses = operation.getResponses();
      apiResponses.forEach((statusCode, apiResponse) -> {
        if ("200".equals(statusCode)) {
          Content content = apiResponse.getContent();
          if (content != null) {
            content.forEach((mediaTypeKey, mediaType) -> {
              Schema<?> originalSchema = mediaType.getSchema();
              if (isApiResponseVoidSchema(originalSchema)) {
                mediaType.setSchema(createSuccessSchema());
              } else {
                // 기존 schema 에서 data 필드만 가져옵니다.
                Schema<?> refSchema = getSchemaByRef(openApi, originalSchema.get$ref());
                Schema<?> dataSchema = extractDataSchema(refSchema);
                mediaType.setSchema(createSuccessSchemaWithData(dataSchema));
              }
            });
          }
        }
      });
    }));
  }

```

`Schema<?> originalSchema = mediaType.getSchema();` 
에서 가져온 Schema 의 경우 $ref 를 제외하고 모든 필드가 null 이였다. data 키만 가져오고 싶었는 데 그럴 수 없어서 다시 ref 를 이용하여 
schema 를 가져오는 코드를 작성했다.  

### TODO
- [x] : 공통 Response 설정

