### PR TITLE
[#43] 주문 생성 API

### DIFF
--- a/hotelking-api/src/main/java/com/hotelking/application/RoomReservationService.java
+++ b/hotelking-api/src/main/java/com/hotelking/application/RoomReservationService.java
@@ -1,18 +1,18 @@
 package com.hotelking.application;
 
-import com.hotelking.domain.hotel.RoomType;
-import com.hotelking.domain.reservation.RoomReservation;
+import com.hotelking.domain.order.Order;
+import com.hotelking.domain.order.OrderRepository;
 import com.hotelking.domain.reservation.RoomReservationRepository;
 import com.hotelking.domain.schedule.ReservationType;
-import com.hotelking.dto.AppUser;
 import com.hotelking.dto.AddRoomReservationDto;
+import com.hotelking.dto.AppUser;
 import com.hotelking.exception.ErrorCode;
 import com.hotelking.exception.HotelkingException;
 import com.hotelking.query.RoomScheduleRepository;
 import com.hotelking.query.RoomTypeQueryRepository;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -21,25 +21,20 @@ public class RoomReservationService {
   private final RoomReservationRepository roomReservationRepository;
   private final RoomScheduleRepository roomScheduleQuery;
   private final RoomTypeQueryRepository roomTypeQueryRepository;
+  private final OrderRepository orderRepository;
 
   public RoomReservationService(RoomReservationRepository roomReservationRepository, RoomScheduleRepository roomScheduleQuery,
-      RoomTypeQueryRepository roomTypeQueryRepository) {
+      RoomTypeQueryRepository roomTypeQueryRepository, OrderRepository orderRepository) {
     this.roomReservationRepository = roomReservationRepository;
     this.roomScheduleQuery = roomScheduleQuery;
     this.roomTypeQueryRepository = roomTypeQueryRepository;
+    this.orderRepository = orderRepository;
   }
 
-  @Transactional
-  public void addOrder(AppUser appUser, AddRoomReservationDto addRoomReservationDto) {
+  public UUID addOrder(AppUser appUser, AddRoomReservationDto addRoomReservationDto) {
     checkRoomRevAvailability(addRoomReservationDto);
-    final RoomType roomType = findRoomType(addRoomReservationDto);
-    RoomReservation roomReservation = addRoomReservationDto.toRoomRevWithType(appUser, roomType);
-    roomReservationRepository.save(roomReservation);
-  }
-
-  private RoomType findRoomType(AddRoomReservationDto addRoomReservationDto) {
-    return roomTypeQueryRepository.findById(addRoomReservationDto.roomTypeId())
-        .orElseThrow(() -> new HotelkingException(ErrorCode.NOT_FOUND_ROOM_TYPE, log));
+    Order savedOrder = orderRepository.save(addRoomReservationDto.toOrder(appUser));
+    return savedOrder.getId();
   }
 
   public void checkRoomRevAvailability(AddRoomReservationDto addRoomReservationDto) {

--- a/hotelking-api/src/main/java/com/hotelking/config/WebConfig.java
+++ b/hotelking-api/src/main/java/com/hotelking/config/WebConfig.java
@@ -26,6 +26,9 @@ public class WebConfig implements WebMvcConfigurer {
             // user
             "/find-user-id",
 
+            // reservation
+            "/order",
+
             // phone auth
             "/phone-verification",
             "/phone-confirm"

--- a/hotelking-api/src/main/java/com/hotelking/controller/reservation/RoomReservationController.java
+++ b/hotelking-api/src/main/java/com/hotelking/controller/reservation/RoomReservationController.java
@@ -21,7 +21,7 @@ public class RoomReservationController {
   }
 
   @PostMapping("/order")
-  public ApiResponse<?> createOrder(
+  public ApiResponse<OrderResponse> createOrder(
       @Login AppUser appUser,
       @RequestBody AddOrderRequest addOrderRequest
   ) {

--- a/hotelking-api/src/main/java/com/hotelking/controller/reservation/RoomReservationController.java
+++ b/hotelking-api/src/main/java/com/hotelking/controller/reservation/RoomReservationController.java
@@ -4,7 +4,9 @@ import com.hotelking.application.RoomReservationService;
 import com.hotelking.auth.Login;
 import com.hotelking.dto.AppUser;
 import com.hotelking.dto.request.AddOrderRequest;
+import com.hotelking.dto.request.OrderResponse;
 import com.hotelking.dto.response.ApiResponse;
+import java.util.UUID;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,14 +20,14 @@ public class RoomReservationController {
     this.roomReservationService = roomReservationService;
   }
 
-  @PostMapping("/reservation")
-  public ApiResponse<?> doReservation(
+  @PostMapping("/order")
+  public ApiResponse<?> createOrder(
       @Login AppUser appUser,
       @RequestBody AddOrderRequest addOrderRequest
   ) {
     addOrderRequest.validationCheck();
-    roomReservationService.addOrder(appUser, addOrderRequest.toOrderDto());
-    return ApiResponse.success();
+    UUID orderKey = roomReservationService.addOrder(appUser, addOrderRequest.toOrderDto());
+    return ApiResponse.success(new OrderResponse(orderKey));
   }
 
 }

--- a/hotelking-api/src/main/java/com/hotelking/dto/AddRoomReservationDto.java
+++ b/hotelking-api/src/main/java/com/hotelking/dto/AddRoomReservationDto.java
@@ -1,6 +1,7 @@
 package com.hotelking.dto;
 
 import com.hotelking.domain.hotel.RoomType;
+import com.hotelking.domain.order.Order;
 import com.hotelking.domain.reservation.RoomReservation;
 import com.hotelking.domain.schedule.ReservationType;
 import java.time.LocalDateTime;
@@ -16,6 +17,17 @@ public record AddRoomReservationDto(
 
   public long getDayDiffer() {
     return ChronoUnit.DAYS.between(checkIn, checkOut);
+  }
+
+  public Order toOrder(AppUser appUser) {
+    return Order.builder()
+        .hotelId(hotelId)
+        .roomTypeId(roomTypeId)
+        .checkIn(checkIn.toLocalDate())
+        .checkOut(checkOut.toLocalDate())
+        .appUser(appUser)
+        .reservationType(reservationType)
+        .build();
   }
 
   public RoomReservation toRoomRevWithType(AppUser user, RoomType roomType) {

--- a/hotelking-api/src/main/java/com/hotelking/dto/request/OrderResponse.java
+++ b/hotelking-api/src/main/java/com/hotelking/dto/request/OrderResponse.java
@@ -1,0 +1,5 @@
+package com.hotelking.dto.request;
+
+import java.util.UUID;
+
+public record OrderResponse(UUID orderKey) { }

--- a/hotelking-core/build.gradle
+++ b/hotelking-core/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    implementation 'org.springframework.data:spring-data-redis'
+    implementation 'io.lettuce:lettuce-core:6.3.1.RELEASE'
+
     // query dsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/hotelking-core/src/main/java/com/hotelking/HotelKingApplication.java
+++ b/hotelking-core/src/main/java/com/hotelking/HotelKingApplication.java
@@ -1,0 +1,13 @@
+package com.hotelking;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HotelKingApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(HotelKingApplication.class, args);
+  }
+}

--- a/hotelking-core/src/main/java/com/hotelking/domain/order/Order.java
+++ b/hotelking-core/src/main/java/com/hotelking/domain/order/Order.java
@@ -1,10 +1,12 @@
 package com.hotelking.domain.order;
 
+import com.hotelking.domain.schedule.ReservationType;
 import com.hotelking.dto.AppUser;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.Objects;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
@@ -21,25 +23,30 @@ public class Order implements Serializable {
   private LocalDate checkOut;
   private Long hotelId;
   private Long roomTypeId;
-  private Integer amount;
   private AppUser appUser;
+  private ReservationType reservationType;
+  private LocalDateTime createdAt;
 
+  @Builder
   public Order(
       UUID id,
       LocalDate checkIn,
       LocalDate checkOut,
       Long hotelId,
       Long roomTypeId,
-      Integer amount,
-      AppUser appUser
+      AppUser appUser,
+      ReservationType reservationType
   ) {
-    this.id = id;
+    if (this.id == null) {
+      this.id = id;
+    }
     this.checkIn = checkIn;
     this.checkOut = checkOut;
     this.hotelId = hotelId;
     this.roomTypeId = roomTypeId;
-    this.amount = amount;
     this.appUser = appUser;
+    this.reservationType = reservationType;
+    this.createdAt = LocalDateTime.now();
   }
 
   @Override
@@ -51,11 +58,11 @@ public class Order implements Serializable {
       return false;
     }
 
-    return Objects.equals(id, order.id);
+    return id.equals(order.id);
   }
 
   @Override
   public int hashCode() {
-    return id != null ? id.hashCode() : 0;
+    return id.hashCode();
   }
 }

--- a/hotelking-core/src/main/java/com/hotelking/domain/order/Order.java
+++ b/hotelking-core/src/main/java/com/hotelking/domain/order/Order.java
@@ -1,0 +1,61 @@
+package com.hotelking.domain.order;
+
+import com.hotelking.dto.AppUser;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@ToString
+@Getter
+@RedisHash(value = "ORDER", timeToLive = 60 * 10)
+public class Order implements Serializable {
+
+  @Id
+  private UUID id;
+  private LocalDate checkIn;
+  private LocalDate checkOut;
+  private Long hotelId;
+  private Long roomTypeId;
+  private Integer amount;
+  private AppUser appUser;
+
+  public Order(
+      UUID id,
+      LocalDate checkIn,
+      LocalDate checkOut,
+      Long hotelId,
+      Long roomTypeId,
+      Integer amount,
+      AppUser appUser
+  ) {
+    this.id = id;
+    this.checkIn = checkIn;
+    this.checkOut = checkOut;
+    this.hotelId = hotelId;
+    this.roomTypeId = roomTypeId;
+    this.amount = amount;
+    this.appUser = appUser;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Order order)) {
+      return false;
+    }
+
+    return Objects.equals(id, order.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id != null ? id.hashCode() : 0;
+  }
+}

--- a/hotelking-core/src/main/java/com/hotelking/domain/order/OrderRepository.java
+++ b/hotelking-core/src/main/java/com/hotelking/domain/order/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.hotelking.domain.order;
+
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface OrderRepository extends CrudRepository<Order, UUID> {
+
+}

--- a/hotelking-core/src/main/resources/application-local.yml
+++ b/hotelking-core/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/hotelking-core/src/test/java/com/hotelking/HotelKingCoreTests.java
+++ b/hotelking-core/src/test/java/com/hotelking/HotelKingCoreTests.java
@@ -1,0 +1,13 @@
+package com.hotelking;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HotelKingCoreTests {
+
+  @Test
+  void contextLoads() {
+  }
+
+}

--- a/hotelking-core/src/test/java/com/hotelking/domain/order/OrderRepositoryTest.java
+++ b/hotelking-core/src/test/java/com/hotelking/domain/order/OrderRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.hotelking.domain.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hotelking.dto.AppUser;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+
+@DataRedisTest
+class OrderRepositoryTest {
+
+  @Autowired
+  OrderRepository orderRepository;
+
+  final UUID orderKey = UUID.randomUUID();
+  final Order order = new Order(
+      orderKey,
+      LocalDate.now(),
+      LocalDate.now(),
+      1L,
+      1L,
+      100_000,
+      new AppUser(1L)
+  );
+
+  @BeforeEach
+  void initSave() {
+    orderRepository.save(order);
+  }
+
+  @Test
+  void findOrderKey() {
+    Order savedOrder = orderRepository.findById(orderKey).get();
+    assertThat(savedOrder).isEqualTo(order);
+  }
+
+}

--- a/hotelking-core/src/test/resources/application.yml
+++ b/hotelking-core/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
### 🎋 연관된 이슈 번호(선택)
- #43 

### 💡 작업동기
- 실제 결제가 이루어지기 전 주문을 생성하고 Redis 에 주문을 저장함

### 🔑 주요 변경사항 및 작업목록
- 주문 생성 시 예약 테이블에 저장 -> Redis 에 임시 저장

### 관련 이슈(특히 에러)

- 개발하면서 공유하고 싶은 부분

1. Order 오브젝트를 저장할 때 이번에는 RedisTemplate 을 사용하지 않고 이번에는 CrudRepository 를 사용하여 저장했습니다. (편리함의 목적이 컷습니다. Spring Data Jpa 에서 제공하는 추상화된 Repository 를 사용하는 것처럼)
2. 실제 Object 가 Redis 에 저장될 때 HSET(HMSET) Operation 뿐 아니라 키가 없으면 지정된 멤버(Order)를 추가하기 전에 새로운 SET가 생성된다는 것을 알았습니다. 그리고 이런 SET의 항목은 CrudRepository 에서 사용되는 많은 Spring Data Redis 작업에 대한 인덱스 역할을 하게 됩니다.
<img width="683" alt="스크린샷 2024-08-02 오후 6 21 00" src="https://github.com/user-attachments/assets/6b9f5a62-37f4-4a4a-b9aa-683fd8b1628c">
<img width="529" alt="스크린샷 2024-08-02 오후 6 21 26" src="https://github.com/user-attachments/assets/0ba5e5d1-fc6a-4f34-beef-8e5afd61a815">

3. @RedisHash 를 사용했을 때 TTL 이 제대로 동작하지 않는 문제가 있습니다. 
key 목록을 관리하는 set 의 element 는 삭제되지 않아서 전체 order 의 개수를 가져와보면 계속해서 늘어나는 문제점이 있습니다.
현재는 order 의 개수가 늘어나고는 있지만, 충분히 Order 개수가 많아지거나 Order 의 Count 를 계산할 경우가 생긴다면 추후 삭제가 필요합니다.
```java
@RedisHash(value = "ORDER", timeToLive = 60 * 10)
public class Order implements Serializable {

  @Id
  private UUID id;
  // ...
```
--- 
참고)
https://engineering.salesforce.com/lessons-learned-using-spring-data-redis-f3121f89bff9/
https://docs.spring.io/spring-data/redis/docs/3.1.11/reference/html/#redis.repositories

- 여러움을 겪었던 부분을 알려주세요
1. Redis Operaion 에 대한 log 를 App 에서는 볼 수 없는 단점. 일일히 들어가서 봐야 한다.

### 그 밖의 질문